### PR TITLE
Add Bookmarks panel with UI, rail nav, and height sync

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -148,7 +148,7 @@ iframe {
   grid-column: 1;
   grid-row: 2 / -1;
   /* Fallback before LcarsRailHeights syncs; overridden inline ≥761px */
-  grid-template-rows: 2.3rem 1fr 0.9fr 1.25fr 0.8fr 1fr;
+  grid-template-rows: 2.3rem 1fr 0.9fr 0.75fr 1.25fr 0.8fr 1fr;
   gap: 0.45rem;
   width: 4.25rem;
   align-self: stretch;
@@ -272,6 +272,7 @@ iframe {
 }
 
 #watchlist,
+#bookmarks,
 #news {
   border-radius: 0 1.35rem 1.35rem 0;
 }
@@ -1741,6 +1742,114 @@ h1 {
   border-color: var(--purple);
 }
 
+
+.bookmarks-panel {
+  padding: 0.9rem 1rem 1rem;
+}
+
+
+.bookmarks-form {
+  display: grid;
+  grid-template-columns: minmax(5rem, 0.8fr) minmax(9rem, 1.6fr) auto;
+  gap: 0.35rem;
+}
+
+.bookmarks-form input,
+.bookmarks-form button {
+  min-height: 1.8rem;
+  border: 0;
+  font-family: var(--font-mono), monospace;
+  font-size: 0.7rem;
+}
+
+.bookmarks-form input {
+  padding: 0.32rem 0.5rem;
+  background: var(--panel-strong);
+  color: var(--text);
+  outline: 1px solid rgba(141, 172, 214, 0.25);
+}
+
+.bookmarks-form button {
+  padding: 0.32rem 0.62rem;
+  background: var(--orange);
+  color: var(--ink);
+  font-family: var(--font-display), sans-serif;
+  font-weight: 900;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  cursor: pointer;
+}
+
+.bookmarks-form button:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.bookmarks-error {
+  margin: 0.55rem 0 0;
+  color: var(--red);
+  font-size: 0.74rem;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+.bookmarks-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(10rem, 1fr));
+  gap: 0.55rem;
+  margin-top: 0.7rem;
+}
+
+.bookmarks-link {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 0.55rem;
+  padding: 0.58rem 0.68rem;
+  border-radius: 0.6rem;
+  background: var(--panel-strong);
+  outline: 1px solid rgba(141, 172, 214, 0.2);
+}
+
+.bookmarks-link:hover {
+  background: var(--lcars-row-hover-vail);
+  outline: var(--lcars-row-hover-outline);
+  box-shadow: var(--lcars-row-hover-inset);
+}
+
+.bookmarks-link a {
+  display: flex;
+  flex-direction: column;
+  gap: 0.2rem;
+  min-width: 0;
+  text-decoration: none;
+}
+
+.bookmarks-link strong {
+  color: var(--gold);
+  font-family: var(--font-display), sans-serif;
+  font-size: 0.85rem;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.bookmarks-link small {
+  color: rgba(249, 210, 138, 0.7);
+  font-size: 0.72rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.bookmarks-link button {
+  border: 0;
+  border-radius: 999px;
+  padding: 0.2rem 0.45rem;
+  background: rgba(141, 172, 214, 0.2);
+  color: var(--text);
+  font-size: 0.62rem;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  cursor: pointer;
+}
 .news-panel {
   display: grid;
   grid-template-rows: auto minmax(0, 1fr);

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -10,6 +10,7 @@ import { DEFAULT_DASHBOARD_LOCATION } from "@/lib/dashboard-location";
 import { LcarsRailHeights } from "@/components/LcarsRailHeights";
 import { LcarsRailNav } from "@/components/LcarsRailNav";
 import { NewsPanel } from "@/components/NewsPanel";
+import { BookmarksPanel } from "@/components/BookmarksPanel";
 import { getWeatherReport } from "@/lib/weather";
 
 const commandBars = [
@@ -48,6 +49,8 @@ export default async function Home() {
           </section>
 
           <WatchlistPanel />
+
+          <BookmarksPanel />
 
           <LocalMapPanels />
 

--- a/components/BookmarksPanel.tsx
+++ b/components/BookmarksPanel.tsx
@@ -1,0 +1,158 @@
+"use client";
+
+import { FormEvent, useEffect, useMemo, useState } from "react";
+
+type Bookmark = {
+  href: string;
+  label: string;
+};
+
+const DEFAULT_BOOKMARKS: Bookmark[] = [
+  { label: "GitHub", href: "https://github.com" },
+  { label: "Gmail", href: "https://mail.google.com" },
+  { label: "Calendar", href: "https://calendar.google.com" },
+  { label: "YouTube", href: "https://www.youtube.com" },
+];
+
+const STORAGE_KEY = "kewldashboard.bookmarks.v1";
+
+function normalizeUrl(raw: string) {
+  const value = raw.trim();
+  if (!value) {
+    return "";
+  }
+  return /^https?:\/\//i.test(value) ? value : `https://${value}`;
+}
+
+export function BookmarksPanel() {
+  const [bookmarks, setBookmarks] = useState<Bookmark[]>(DEFAULT_BOOKMARKS);
+  const [labelInput, setLabelInput] = useState("");
+  const [urlInput, setUrlInput] = useState("");
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const saved = window.localStorage.getItem(STORAGE_KEY);
+    if (!saved) {
+      return;
+    }
+
+    try {
+      const parsed = JSON.parse(saved) as unknown;
+      if (!Array.isArray(parsed)) {
+        return;
+      }
+
+      const restored = parsed
+        .map((item) => {
+          if (!item || typeof item !== "object") {
+            return null;
+          }
+          const label = "label" in item && typeof item.label === "string" ? item.label.trim() : "";
+          const href = "href" in item && typeof item.href === "string" ? normalizeUrl(item.href) : "";
+          if (!label || !href) {
+            return null;
+          }
+          return { label: label.slice(0, 40), href };
+        })
+        .filter((item): item is Bookmark => item !== null)
+        .slice(0, 12);
+
+      if (restored.length > 0) {
+        setBookmarks(restored);
+      }
+    } catch {
+      window.localStorage.removeItem(STORAGE_KEY);
+    }
+  }, []);
+
+  useEffect(() => {
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(bookmarks));
+  }, [bookmarks]);
+
+  const canSubmit = useMemo(() => labelInput.trim() && urlInput.trim(), [labelInput, urlInput]);
+
+  function addBookmark(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    setError(null);
+
+    const label = labelInput.trim().slice(0, 40);
+    const href = normalizeUrl(urlInput);
+
+    if (!label || !href) {
+      setError("Label and URL are required.");
+      return;
+    }
+
+    let parsed: URL;
+    try {
+      parsed = new URL(href);
+    } catch {
+      setError("Enter a valid URL (example.com or https://example.com).");
+      return;
+    }
+
+    if (!["http:", "https:"].includes(parsed.protocol)) {
+      setError("Only http and https links are supported.");
+      return;
+    }
+
+    if (bookmarks.some((bookmark) => bookmark.href === parsed.href || bookmark.label.toLowerCase() === label.toLowerCase())) {
+      setError("Bookmark already exists.");
+      return;
+    }
+
+    setBookmarks((current) => [{ label, href: parsed.href }, ...current].slice(0, 12));
+    setLabelInput("");
+    setUrlInput("");
+  }
+
+  function removeBookmark(href: string) {
+    setBookmarks((current) => current.filter((bookmark) => bookmark.href !== href));
+  }
+
+  return (
+    <section id="bookmarks" className="panel bookmarks-panel scroll-target" aria-label="Website bookmarks">
+      <div className="panel-heading watchlist-heading">
+        <div>
+          <span>Quick Links</span>
+          <strong>Website Bookmarks</strong>
+        </div>
+        <form className="bookmarks-form" onSubmit={addBookmark}>
+          <input
+            value={labelInput}
+            onChange={(event) => setLabelInput(event.target.value)}
+            placeholder="Label"
+            maxLength={40}
+            aria-label="Bookmark label"
+          />
+          <input
+            value={urlInput}
+            onChange={(event) => setUrlInput(event.target.value)}
+            placeholder="example.com"
+            maxLength={120}
+            aria-label="Bookmark URL"
+          />
+          <button type="submit" disabled={!canSubmit}>
+            Add
+          </button>
+        </form>
+      </div>
+
+      {error ? <p className="bookmarks-error">{error}</p> : null}
+
+      <div className="bookmarks-grid" role="list" aria-label="Saved bookmarks">
+        {bookmarks.map((bookmark) => (
+          <article key={bookmark.href} className="bookmarks-link" role="listitem">
+            <a href={bookmark.href} target="_blank" rel="noopener noreferrer">
+              <strong>{bookmark.label}</strong>
+              <small>{new URL(bookmark.href).hostname.replace(/^www\./, "")}</small>
+            </a>
+            <button type="button" onClick={() => removeBookmark(bookmark.href)} aria-label={`Remove ${bookmark.label}`}>
+              Remove
+            </button>
+          </article>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/components/LcarsRailHeights.tsx
+++ b/components/LcarsRailHeights.tsx
@@ -32,6 +32,7 @@ export function LcarsRailHeights() {
 
       const systems = document.getElementById("systems");
       const watchlist = document.getElementById("watchlist");
+      const bookmarks = document.getElementById("bookmarks");
       const mapPanels = document.getElementById("map-panels");
       const radar = document.getElementById("radar");
       const traffic = document.getElementById("traffic");
@@ -40,6 +41,7 @@ export function LcarsRailHeights() {
       const minSeg = 52;
       const hOverview = Math.max(readHeight(systems), minSeg);
       const hSystems = Math.max(readHeight(watchlist), minSeg);
+      const hBookmarks = Math.max(readHeight(bookmarks), minSeg);
 
       let hRadar: number;
       let hTraffic: number;
@@ -58,6 +60,7 @@ export function LcarsRailHeights() {
         "2.3rem",
         `${hOverview}px`,
         `${hSystems}px`,
+        `${hBookmarks}px`,
         `${hRadar}px`,
         `${hTraffic}px`,
         `${hNews}px`,
@@ -70,7 +73,7 @@ export function LcarsRailHeights() {
     }
 
     function getSectionElements(): HTMLElement[] {
-      const ids = ["systems", "watchlist", "map-panels", "radar", "traffic", "news"] as const;
+      const ids = ["systems", "watchlist", "bookmarks", "map-panels", "radar", "traffic", "news"] as const;
       const list: HTMLElement[] = [];
       for (const id of ids) {
         const el = document.getElementById(id);

--- a/components/LcarsRailNav.tsx
+++ b/components/LcarsRailNav.tsx
@@ -5,6 +5,7 @@ import { scrollToDashboardTarget } from "@/lib/dashboard-pills";
 const RAIL_LINKS = [
   { href: "#systems", label: "Overview", className: "rail-segment rail-orange" },
   { href: "#watchlist", label: "Systems", className: "rail-segment rail-gold" },
+  { href: "#bookmarks", label: "Links", className: "rail-segment rail-gold" },
   { href: "#radar", label: "Radar", className: "rail-segment rail-peach" },
   { href: "#traffic", label: "Traffic", className: "rail-segment rail-purple" },
   { href: "#news", label: "News", className: "rail-segment rail-blue" },

--- a/lib/dashboard-pills.ts
+++ b/lib/dashboard-pills.ts
@@ -16,6 +16,7 @@ export const CONTROL_PILLS: ControlPill[] = [
   { label: "Atmospheric Scan", targetId: "weather", accent: "orange" },
   { label: "Market Telemetry", targetId: "markets", accent: "orange" },
   { label: "Market Core", targetId: "watchlist", accent: "gold" },
+  { label: "Quick Links", targetId: "bookmarks", accent: "gold" },
   { label: "Weather Radar", targetId: "radar", accent: "peach" },
   { label: "Traffic", targetId: "traffic", accent: "purple" },
   { label: "Subspace Feed", targetId: "news", accent: "blue" },


### PR DESCRIPTION
### Motivation
- Introduce a quick-access bookmarks panel so users can store and open frequently used websites from the dashboard.
- Integrate the new panel with the LCARS rail navigation and the responsive rail height calculation so layout and scrolling remain consistent.
- Provide a small, client-side persisted UI with validation and a bounded number of saved links to keep the dashboard lightweight.

### Description
- Added a new `BookmarksPanel` React component in `components/BookmarksPanel.tsx` that provides a client-side form to add bookmarks, validation, duplicate checking, removal, and `localStorage` persistence using the key `kewldashboard.bookmarks.v1`.
- Integrated the panel into the main page by importing and rendering `BookmarksPanel` in `app/page.tsx` and updated `CONTROL_PILLS` in `lib/dashboard-pills.ts` to include the `bookmarks` target.
- Added a new rail link for `#bookmarks` in `components/LcarsRailNav.tsx` and updated `LcarsRailHeights.tsx` to measure the bookmarks panel height and observe it for responsive rail row sizing and resize handling.
- Updated `app/globals.css` to expand the rail fallback `grid-template-rows`, include the `#bookmarks` selector for panel border radius, and add styles for the bookmarks panel form, grid, links, error messages, and buttons.

### Testing
- Performed a TypeScript type check and development build (`next build` / `tsc`), which completed without type or build errors.
- No new automated unit tests were added for the bookmarks feature; existing test suites were not modified and continue to run as before.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f945aa26f0833399c6e1c005f75ab7)